### PR TITLE
convert integer keys to strings when writing to TOML files

### DIFF
--- a/pyconfs/writers/toml.py
+++ b/pyconfs/writers/toml.py
@@ -21,7 +21,20 @@ def as_toml(
     config: Dict[str, Any], pretty_print: bool = False, **toml_args: Any
 ) -> None:
     """Use toml library to write TOML file"""
+    config_with_str_keys = _enforce_str_keys(config)
+
     if pretty_print:
-        return Configuration.from_dict(config).as_str(**toml_args)
+        return Configuration.from_dict(config_with_str_keys).as_str(
+            **toml_args
+        )
     else:
-        return toml.dumps(config, **toml_args)
+        return toml.dumps(config_with_str_keys, **toml_args)
+
+
+def _enforce_str_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Changes keys in nested dicts to strings."""
+    if isinstance(data, dict):
+        return {
+            str(key): _enforce_str_keys(value) for key, value in data.items()
+        }
+    return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Common fixtures for all tests"""
+
+# Third party imports
+import pytest
+
+# PyConfs imports
+import pyconfs
+
+
+@pytest.fixture
+def cfg():
+    """A basic configuration for testing"""
+    return pyconfs.Configuration.from_dict(
+        {
+            "name": "pyconfs",
+            "dependencies": [
+                {
+                    "name": "python",
+                    "url": "https://www.python.org/",
+                    "versions": [3.6, 3.7, 3.8, 3.9],
+                },
+                {"name": "pyplugs", "url": "https://pyplugs.readthedocs.io"},
+            ],
+            "author": {"firstname": "Geir Arne", "lastname": "Hjelle"},
+            "files": {
+                "configuration": "{basepath}/pyconfs/configuration.py",
+                "toml-reader": "{basepath}/pyconfs/readers/toml.py",
+                "test": "{basepath}/tests/test_configuration.py",
+            },
+            "number": 7,
+        },
+        name="test_config",
+    )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -7,34 +7,7 @@ import pathlib
 import pytest
 
 # PyConfs imports
-import pyconfs
 from pyconfs import _exceptions
-
-
-@pytest.fixture
-def cfg():
-    """A basic configuration for testing"""
-    return pyconfs.Configuration.from_dict(
-        {
-            "name": "pyconfs",
-            "dependencies": [
-                {
-                    "name": "python",
-                    "url": "https://www.python.org/",
-                    "versions": [3.6, 3.7, 3.8, 3.9],
-                },
-                {"name": "pyplugs", "url": "https://pyplugs.readthedocs.io"},
-            ],
-            "author": {"firstname": "Geir Arne", "lastname": "Hjelle"},
-            "files": {
-                "configuration": "{basepath}/pyconfs/configuration.py",
-                "toml-reader": "{basepath}/pyconfs/readers/toml.py",
-                "test": "{basepath}/tests/test_configuration.py",
-            },
-            "number": 7,
-        },
-        name="test_config",
-    )
 
 
 def test_replace(cfg):
@@ -65,7 +38,8 @@ def test_replace_converter(cfg):
 def test_replace_callable_converter(cfg):
     """Test that a callable can be used as a converter when doing replace"""
     assert isinstance(
-        cfg.files.replace("test", basepath="", converter=pathlib.Path), pathlib.Path
+        cfg.files.replace("test", basepath="", converter=pathlib.Path),
+        pathlib.Path,
     )
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -16,6 +16,22 @@ def sample_dir():
     return pathlib.Path(__file__).parent / "files"
 
 
+@pytest.fixture
+def cfg_with_int_key():
+    """Configuration with a key that is an integer"""
+    return Configuration.from_dict(
+        {
+            "answer": {42: "Life, the Universe, and Everything"},
+            "long_answer": {
+                "parts": {
+                    1: "The Answer to the Ultimate Question of",
+                    2: "Life, the Universe, and Everything",
+                },
+            },
+        }
+    )
+
+
 def test_read_ini(sample_dir):
     """Test that reading an INI file succeeds"""
     Configuration.from_file(sample_dir / "sample.ini")
@@ -27,6 +43,26 @@ def test_read_ini_sources(sample_dir):
     cfg = Configuration.from_file(cfg_path)
 
     assert cfg.sources == {f"{cfg_path} (INI reader)"}
+
+
+@pytest.mark.skip("INI does not yet support advanced reading")
+def test_ini_roundtrip(cfg):
+    """Test that a configuration can be recovered after being stored as INI"""
+    roundtripped = Configuration.from_str(
+        cfg.as_str(format="ini"), format="ini"
+    )
+
+    assert roundtripped.as_dict() == cfg.as_dict()
+
+
+def test_ini_handle_int_key_gracefully(cfg_with_int_key):
+    """Test that INI format handles int keys gracefully"""
+    roundtripped = Configuration.from_str(
+        cfg_with_int_key.as_str(format="ini"), format="ini"
+    )
+
+    # INI converts integer keys to strings
+    assert roundtripped.answer.entry_keys == ["42"]
 
 
 def test_read_json(sample_dir):
@@ -42,6 +78,25 @@ def test_read_json_sources(sample_dir):
     assert cfg.sources == {f"{cfg_path} (JSON reader)"}
 
 
+def test_json_roundtrip(cfg):
+    """Test that a configuration can be recovered after being stored as JSON"""
+    roundtripped = Configuration.from_str(
+        cfg.as_str(format="json"), format="json"
+    )
+
+    assert roundtripped.as_dict() == cfg.as_dict()
+
+
+def test_json_handle_int_key_gracefully(cfg_with_int_key):
+    """Test that JSON format handles int keys gracefully"""
+    roundtripped = Configuration.from_str(
+        cfg_with_int_key.as_str(format="json"), format="json"
+    )
+
+    # JSON converts integer keys to strings
+    assert roundtripped.answer.entry_keys == ["42"]
+
+
 def test_read_toml(sample_dir):
     """Test that reading a TOML file succeeds"""
     Configuration.from_file(sample_dir / "sample.toml")
@@ -55,6 +110,26 @@ def test_read_toml_sources(sample_dir):
     assert cfg.sources == {f"{cfg_path} (TOML reader)"}
 
 
+def test_toml_roundtrip(cfg):
+    """Test that a configuration can be recovered after being stored as TOML"""
+    roundtripped = Configuration.from_str(
+        cfg.as_str(format="toml"), format="toml"
+    )
+
+    assert roundtripped.as_dict() == cfg.as_dict()
+
+
+def test_toml_handle_int_key_gracefully(cfg_with_int_key):
+    """Test that TOML format handles int keys gracefully"""
+    roundtripped = Configuration.from_str(
+        cfg_with_int_key.as_str(format="toml"), format="toml"
+    )
+
+    # TOML converts integer keys to strings
+    assert roundtripped.answer.entry_keys == ["42"]
+    assert roundtripped.long_answer.parts.entry_keys == ["1", "2"]
+
+
 def test_read_yaml(sample_dir):
     """Test that reading a YAML file succeeds"""
     Configuration.from_file(sample_dir / "sample.yaml")
@@ -66,3 +141,22 @@ def test_read_yaml_sources(sample_dir):
     cfg = Configuration.from_file(cfg_path)
 
     assert cfg.sources == {f"{cfg_path} (YAML reader)"}
+
+
+def test_yaml_roundtrip(cfg):
+    """Test that a configuration can be recovered after being stored as YAML"""
+    roundtripped = Configuration.from_str(
+        cfg.as_str(format="yaml"), format="yaml"
+    )
+
+    assert roundtripped.as_dict() == cfg.as_dict()
+
+
+def test_yaml_handle_int_key_gracefully(cfg_with_int_key):
+    """Test that YAML format handles int keys gracefully"""
+    roundtripped = Configuration.from_str(
+        cfg_with_int_key.as_str(format="yaml"), format="yaml"
+    )
+
+    # YAML supports integer keys
+    assert roundtripped.as_dict() == cfg_with_int_key.as_dict()


### PR DESCRIPTION
Integers as keys are not supported by [`toml.dumps`](https://github.com/uiri/toml/blob/master/toml/encoder.py#L34). I suggest including this capability in PyConfs since it is supported when writing to `json`, `yaml`, and `ini`.

**Testing `toml`directly**

```python
import toml

int_as_key = {1: {2: "three"}}
str_as_key = {"1": {"2": "three"}}

print(int_as_key)
print(str_as_key)
print()

try:
    with open("with_integer.toml", "w") as f:
        formated_with_dumps = toml.dump(int_as_key, f)
except KeyError:
    print("KeyError")
    with open("with_string.toml", "w") as f:
        formated_with_dumps = toml.dump(str_as_key, f)

print()
print(formated_with_dumps)
```

Output:
```bash
{1: {2: 'three'}}
{'1': {'2': 'three'}}

KeyError

[1]
2 = "three"
```